### PR TITLE
Escape all forward slashes to allow sub-directories

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -76,7 +76,7 @@ function UserInfo() {
 }
 
 window.user_info = new UserInfo();
-window.base_url = 'BASE_URL/' + Cypress.config('baseUrl').replace('http://', 'http\\:\\\\/\\\\/')
+window.base_url = 'BASE_URL/' + Cypress.config('baseUrl').replace(/\//g, "\\\\/")
 
 //Set the Base URL in the REDCap Configuration Database
 // if(Cypress.config('baseUrl') !== null){


### PR DESCRIPTION
# The Problem
If the baseUrl in cypress.json contains a subdirectory, the test run fails.

This issue can be recreated using the aldefouw/redcap-docker-compose repository by amending app volumes setting in the docker-compose.yml file to '../www/:/var/www/app/public_html/sub' and changing the baseUrl in cypress.json to "http://localhost:8080/sub".

# The Fix
I have amended the escaping of the baseUrl parameter in support/index.js to escape all forward slashes, not just those at the start of the URL.