### PR TITLE
Update cypress.config.js.example

### DIFF
--- a/cypress.config.js.example
+++ b/cypress.config.js.example
@@ -6,7 +6,7 @@ module.exports = defineConfig({
     e2e: {
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
-        async setupNodeEvents(on, config) {
+        setupNodeEvents(on, config) {
             require('rctf/plugins/index.js')(on, config)
             return config
         },


### PR DESCRIPTION
Having intermittent issues with "async" keyword before setupNodeEvents method.  

Sometimes getting Error: ENOENT ... fixed by a refreshed browser but that is going to cause annoyance for developers.

Seems like developer environment works WAY better without it.