### PR TITLE
add del-cli and move-cli modules to help clean. need move-cli because…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "devDependencies": {
     "cypress": "^13.14.1",
     "rctf": "git://github.com/aldefouw/rctf#v1.0.95",
-    "redcap_rsvc": "git://github.com/aldefouw/redcap_rsvc#v13.1.37"
+    "redcap_rsvc": "git://github.com/aldefouw/redcap_rsvc#v13.1.37-ABC",
+    "del-cli": "^5.1.0",
+    "move-cli": "^2.0.0"
   },
   "optionalDependencies": {
     "redcap_cypress_doc_theme": "git://github.com/aldefouw/redcap_cypress_doc_theme#bf84bfa"
@@ -18,7 +20,8 @@
     "reflect-metadata": "0.2.2"
   },
   "scripts": {
-    "redcap_rsvc:install": "npm install && mv node_modules/redcap_rsvc ./redcap_rsvc",
+    "clean": "del-cli node_modules/redcap_rsvc redcap_rsvc package-lock.json",
+    "redcap_rsvc:install": "npm run clean && npm install && move-cli node_modules/redcap_rsvc ./redcap_rsvc",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs:build": "npm install git://github.com/documentationjs/documentation#97e9361 --no-save && ./node_modules/.bin/documentation build ./node_modules/rctf/step_definitions/* ./node_modules/rctf/step_definitions/support/* -f html --theme node_modules/redcap_cypress_doc_theme/index.js -o docs"
   },


### PR DESCRIPTION
… "mv" was throwing errors in a windows environment.

Helps solve issue with updating the RSVC version. 

Basically, it will remove the redcap_rsvc module, and remove the lock file so the new install will be clean.

Add modules del-cli and move-cli to allow deletes and directory moves on any platform.