### PR TITLE
Pull redcap source from vumc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,16 @@
+version: 2.1
+
 orbs:
   codecov: codecov/codecov@4.0.1
 
+executors:
+  shared-executor:
+    machine:
+      image: ubuntu-2404:2024.05.1 # Machine image updates: https://circleci.com/developer/machine/image/ubuntu-2404
+      resource_class: large
+    environment:
+      REDCAP_VERSION: "14.9.4"
+            
 workflows:
   version: 2
   workflows:
@@ -12,14 +22,32 @@ workflows:
           requires:
             - run-tests
 
+commands:
+  setup-redcap:
+    parameters:
+      dir:
+        type: string
+        default: "."
+    steps:
+      - add_ssh_keys
+      - run:
+          name: Build the REDCap Image
+          command: |
+            cd << parameters.dir >>
+            git clone --branch xdebug https://github.com/aldefouw/redcap_docker
+      - run:
+          name: Get REDCap Source
+          command: |
+            cd << parameters.dir >>
+            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa" git clone --branch redcap-cypress --depth=1 https://github.com/aldefouw/redcap_source
+            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_042ee976ef53cbd6ec78fbf9742292ca" git clone --branch ${REDCAP_VERSION} --depth=1 git@github.com:vanderbilt-redcap/REDCap.git redcap_source/redcap_v${REDCAP_VERSION}
+
 jobs:
   run-tests:
-    machine:
-      image: ubuntu-2404:2024.05.1 # Machine image updates: https://circleci.com/developer/machine/image/ubuntu-2404
-      resource_class: large
+    executor: shared-executor
     parallelism: 28
     environment:
-      REDCAP_VERSION: "13.1.37"
+      BOOTSTRAPPING_REDCAP_VERSION: "13.1.37" # Do not change this
     steps:
       - checkout
       - run:
@@ -27,28 +55,21 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install mysql-client-core-8.0
-      - run:
-          name: Build the REDCap Image
-          command: |
-            git clone --branch xdebug https://github.com/aldefouw/redcap_docker
-      - run:
-          name: Get REDCap Source
-          command: |
-            git clone --branch redcap-cypress https://github.com/aldefouw/redcap_source
+      - setup-redcap
       - run:
           name: Start Docker REDCap Container
           command: |
             cd /home/circleci/project/redcap_docker
-            REDCAP_VERSION=${REDCAP_VERSION} docker-compose up -d
+            REDCAP_VERSION=${BOOTSTRAPPING_REDCAP_VERSION} docker-compose up -d
       - run:
           name: Install composer dependencies
           command: |
-            docker exec -it redcap_docker-app-1 sh -c "cd /var/www/html/redcap_v${REDCAP_VERSION} && COMPOSER_DISABLE_XDEBUG_WARN=1 composer install"
+            docker exec -it redcap_docker-app-1 sh -c "cd /var/www/html/redcap_v${BOOTSTRAPPING_REDCAP_VERSION} && COMPOSER_DISABLE_XDEBUG_WARN=1 composer install"
       - run:
           name: Reload REDCap
           command: |
             cd /home/circleci/project/redcap_docker
-            docker-compose down && REDCAP_VERSION=${REDCAP_VERSION} docker-compose up -d
+            docker-compose down && REDCAP_VERSION=${BOOTSTRAPPING_REDCAP_VERSION} docker-compose up -d
       - run:
           name: Permissions on coverage files
           command: |
@@ -64,7 +85,7 @@ jobs:
             cd /home/circleci/project
             sed s/PID/$PROJECT_ID/g cypress.config.js.example > cypress.config.js
             mv cypress.env.json.example cypress.env.json
-
+            sed -i '/  "redcap_version": ".*",/c\  "redcap_version": "'${REDCAP_VERSION}'",' cypress.env.json
       - run:
           name: Install Cypress
           command: |
@@ -95,25 +116,13 @@ jobs:
             - cypress/videos
 
   html-reports:
-    machine:
-      image: ubuntu-2404:2024.05.1 # Machine image updates: https://circleci.com/developer/machine/image/ubuntu-2404
-      resource_class: large
-    environment:
-      REDCAP_VERSION: "13.1.37"
+    executor: shared-executor
     steps:
       - checkout
       - attach_workspace:
           at: /home/circleci/project/coverage
-      - run:
-          name: Build the REDCap Image
-          command: |
-            cd /home/circleci/project/
-            git clone --branch xdebug https://github.com/aldefouw/redcap_docker
-      - run:
-          name: Get REDCap Source
-          command: |
-            cd /home/circleci/project/
-            git clone --branch redcap-cypress https://github.com/aldefouw/redcap_source
+      - setup-redcap:
+          dir: "/home/circleci/project/"
       - run:
           name: Start Docker REDCap Container
           command: |
@@ -130,7 +139,7 @@ jobs:
             cd /home/circleci/project/redcap_source
             git add "html-report-${REDCAP_VERSION}.zip"
             git commit -m "Add latest HTML Report for version ${REDCAP_VERSION}"
-            git push origin redcap-cypress
+            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa" git push origin redcap-cypress
 
       - store_artifacts:
           path: /home/circleci/project/coverage/cypress/videos

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "@badeball/cypress-cucumber-preprocessor": "^20.1.0"
       },
       "devDependencies": {
-        "cypress": "^13.15.0",
+        "cypress": "^13.16.1",
         "del-cli": "^5.1.0",
         "move-cli": "^2.0.0",
-        "rctf": "git://github.com/aldefouw/rctf#v1.0.101",
+        "rctf": "git://github.com/aldefouw/rctf#v1.0.108",
         "redcap_rsvc": "git://github.com/4bbakers/redcap_rsvc#v14.7.0"
       },
       "optionalDependencies": {
@@ -541,12 +541,12 @@
       }
     },
     "node_modules/@bahmutov/cypress-esbuild-preprocessor": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.2.3.tgz",
-      "integrity": "sha512-YdrZxCULKC3k5H5bjBeL6boadcsSXsdnJf6GQGHMRcqzUFzDQC1sZGNblauJzUU34XbA4Sko5ym4KajKf4WwAw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.2.4.tgz",
+      "integrity": "sha512-t5xOKK+a6PlsxgRBtZDzayUcPJGDLKJt1pwKK/Y8szuDPPF+DbEsrqL8fbKgE1+koPvOVaYMX4ggwQwqfk99hA==",
       "dev": true,
       "dependencies": {
-        "debug": "4.3.7"
+        "debug": "4.4.0"
       },
       "peerDependencies": {
         "esbuild": ">=0.17.0"
@@ -2070,9 +2070,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.0.tgz",
-      "integrity": "sha512-g6XcwqnvzXrqiBQR/5gN+QsyRmKRhls1y5E42fyOvsmU7JuY+wM6uHJWj4ZPttjabzbnRvxcik2WemR8+xT6FA==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.6",
@@ -2163,9 +2163,9 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4369,24 +4369,24 @@
       }
     },
     "node_modules/rctf": {
-      "version": "1.0.100",
-      "resolved": "git+ssh://git@github.com/aldefouw/rctf.git#b87b94b7fe286682ff11efe8bce9ff9692d80243",
+      "version": "1.0.108",
+      "resolved": "git+ssh://git@github.com/aldefouw/rctf.git#7b63a03dc996cdb41dc98810e364f02e71c9c178",
       "dev": true,
       "dependencies": {
-        "@4tw/cypress-drag-drop": "^2.2.3",
+        "@4tw/cypress-drag-drop": "^2.2.5",
         "@badeball/cypress-cucumber-preprocessor": "^20.1.2",
-        "@bahmutov/cypress-esbuild-preprocessor": "^2.2.2",
+        "@bahmutov/cypress-esbuild-preprocessor": "^2.2.4",
         "@foreachbe/cypress-tinymce": "^1.0.0",
         "async-csv": "^2.1.3",
         "compare-versions": "3.6.0",
         "cypress-on-fix": "^1.0.3",
-        "cypress-wait-until": "^3.0.1",
+        "cypress-wait-until": "^3.0.2",
         "pdf-parse": "^1.1.1",
         "sed-lite": "0.8.4",
         "shelljs": "0.8.5"
       },
       "peerDependencies": {
-        "cypress": "^13.13.0"
+        "cypress": "^13.16.1"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "cypress": "^13.16.1",
     "del-cli": "^5.1.0",
     "move-cli": "^2.0.0",
-    "rctf": "git://github.com/aldefouw/rctf#v1.0.102",
+    "rctf": "git://github.com/aldefouw/rctf#v1.0.108",
     "redcap_rsvc": "git://github.com/4bbakers/redcap_rsvc#v14.7.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
@aldefouw, the main goal of these changes is to make it really easy to run all tests against new versions of REDCap by only changed the REDCap version in a single place.  I was also able to reduce some duplication in the CircleCI config by leveraging some newer configuration reuse options.  [Click here](https://cloud.cypress.io/projects/pvu79o/runs/2013/overview?roarHideRunsWithDiffGroupsAndTags=1) for the results of a build including these changes.  It looks like a few scenarios are failing against REDCap 14.9.4.  I'll figure out which onese and look into them.  