### PR TITLE
Validated feature filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "npm install && del-cli node_modules redcap_rsvc package-lock.json && npm install",
     "redcap_rsvc:install": "npm run clean && npm run redcap_rsvc:move_files",
     "redcap_rsvc:move_files": "del-cli cypress/fixtures/cdisc_files && del-cli cypress/fixtures/dictionaries && del-cli cypress/fixtures/import_files && move-cli node_modules/redcap_rsvc redcap_rsvc && cp -a redcap_rsvc/Files/* cypress/fixtures/",
-    "redcap_rsvc:validate_features": "npm install gherkin-parse glob-fs --no-save --silent --ignore-scripts && node validate_feature_files.js",
+    "redcap_rsvc:validate_features": "npm install gherkin-parse glob-fs --no-save --silent --ignore-scripts && node validate_feature_files.js && sh validate_feature_files.sh",
     "redcap_rsvc:single_test": "CYPRESS_prettyEnabled=true npx cypress run --spec redcap_rsvc/Feature\\ Tests/A/Configuration\\ Check_1/A.1.1.0100.\\ -\\ Run\\ Configuration\\ Check.feature --browser chrome",
     "redcap_rsvc:all_tests": "CYPRESS_prettyEnabled=true npx cypress run --record --key $RECORD_KEY --parallel --group core-tests --browser chrome",
     "redcap_rsvc:run_official_tests": "npm run redcap_rsvc:all_tests || true",

--- a/validate_feature_files.js
+++ b/validate_feature_files.js
@@ -16,9 +16,10 @@ function validateFeatureFile(filePath) {
     try {
         parser.convertFeatureFileToJSON(filePath)
     } catch (error) {
-        console.error(`${filePath} is invalid - contains PARSE ERRORS.`);
-        process.exit(1) // Exit with non-zero code so run.sh stops
+        return false
     }
+
+    return true
 }
 
 // Debugging: Log the start of glob search
@@ -35,8 +36,19 @@ if (files.length === 0) {
     console.log('No .feature files found matching the pattern.');
 } else {
     // Validate each found feature file
+    const failedFiles = []
     files.forEach(file => {
         const filePath = path.join(BASE_DIR, file); // Get full file path
-        validateFeatureFile(filePath);
+        if (!validateFeatureFile(filePath)) {
+            failedFiles.push(filePath)
+        }
     });
+
+    if (failedFiles.length !== 0) {
+        failedFiles.forEach(filePath => {
+            console.error(`${filePath} is invalid - contains PARSE ERRORS.`);
+        });
+
+        process.exit(1) // Exit with non-zero code so run.sh stops
+    }
 }

--- a/validate_feature_files.js
+++ b/validate_feature_files.js
@@ -17,6 +17,7 @@ function validateFeatureFile(filePath) {
         parser.convertFeatureFileToJSON(filePath)
     } catch (error) {
         console.error(`${filePath} is invalid - contains PARSE ERRORS.`);
+        process.exit(1) // Exit with non-zero code so run.sh stops
     }
 }
 

--- a/validate_feature_files.sh
+++ b/validate_feature_files.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Base directory for
+repo_a_dir=redcap_rsvc
+
+exitCode=0
+
+# Required to retain variables from the while loop's subshell
+shopt -s lastpipe
+
+# Find all `.feature` files in Repo A
+find "$repo_a_dir" -type f -name "*.feature" | while read -r file; do
+  # Extract the directory and filename
+  dir=${file%/*}
+  base=${file##*/}
+
+  # Match and extract the parts of the filename
+  if [[ "$base" =~ ([A-C]\.[0-9]+\.[0-9]+\.)[0-9]+ ]]; then
+    prefix="${BASH_REMATCH[1]}"                # Prefix up to the third period
+    number="${base:${#prefix}:$((${#base} - ${#prefix}))}" # Extract after prefix
+    number="${number%%[^0-9]*}"                # Extract numeric portion
+    number=$((10#$number))                     # Ensure number is treated as decimal
+    padded_number=$(printf "%04d" "$number")   # Pad number to 4 digits
+    suffix="${base#* - }"                      # Suffix after " - "
+
+    # Pad the number to four digits
+    padded_number=$(printf "%04d" "$number")
+
+    # Construct the new filename
+    new_base="${prefix}${padded_number}. - ${suffix}"
+
+    # echo "Processing file: $file"
+    # echo "Prefix: $prefix"
+    # echo "Number: $number"
+    # echo "Suffix: $suffix"
+    # echo "New Base: $new_base"
+
+    if [ "$file" != "$dir/$new_base" ]; then
+      echo "Invalid feature file name: Expected \"$dir/$new_base\" but found \"$file\"."
+      exitCode=1
+    fi
+
+    # Uncomment this line to rename the file
+    # mv "$file" "$dir/$new_base"
+  fi
+done
+
+if [ $exitCode -ne 0 ]; then
+  echo
+  echo "Either rename the files above manually, or uncomment the 'mv' line above to allow this script do it automatically."
+fi
+
+exit $exitCode


### PR DESCRIPTION
@aldefouw, this incorporates the [reformat_feature_names.sh](https://github.com/aldefouw/redcap_rsvc/blob/v14.7.0/reformat_feature_names.sh) script you made, but in a little different way.  Automatically running it in `run.sh` alongside `validate_feature_files.js` should help us improve "fail fast" behavior, and hopefully catch future name issues automatically prior to commit (or at least prior to PR merge).  What are your thoughts?