### PR TITLE
Removed dependence on redcap_source repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
 jobs:
   run-tests:
     executor: shared-executor
-    parallelism: 26
+    parallelism: 30
     environment:
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
     executor: shared-executor
     parallelism: 26
     environment:
-      BOOTSTRAPPING_REDCAP_VERSION: "13.1.37" # Do not change this
     steps:
       - checkout
       - run:
@@ -60,16 +59,16 @@ jobs:
           name: Start Docker REDCap Container
           command: |
             cd /home/circleci/project/redcap_docker
-            REDCAP_VERSION=${BOOTSTRAPPING_REDCAP_VERSION} docker-compose up -d
+            REDCAP_VERSION=${REDCAP_VERSION} docker-compose up -d
       - run:
           name: Install composer dependencies
           command: |
-            docker exec -it redcap_docker-app-1 sh -c "cd /var/www/html/redcap_v${BOOTSTRAPPING_REDCAP_VERSION} && COMPOSER_DISABLE_XDEBUG_WARN=1 composer install"
+            docker exec -it redcap_docker-app-1 sh -c "cd /var/www/html/redcap_v${REDCAP_VERSION} && COMPOSER_DISABLE_XDEBUG_WARN=1 composer require --dev phpunit/php-code-coverage:^11"
       - run:
           name: Reload REDCap
           command: |
             cd /home/circleci/project/redcap_docker
-            docker-compose down && REDCAP_VERSION=${BOOTSTRAPPING_REDCAP_VERSION} docker-compose up -d
+            docker-compose down && REDCAP_VERSION=${REDCAP_VERSION} docker-compose up -d
       - run:
           name: Permissions on coverage files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,12 @@ commands:
           name: Get REDCap Source
           command: |
             cd << parameters.dir >>
-            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa" git clone --branch redcap-cypress --depth=1 https://github.com/aldefouw/redcap_source
-            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_042ee976ef53cbd6ec78fbf9742292ca" git clone --depth=1 git@github.com:vanderbilt-redcap/REDCap.git redcap_source/redcap_v${REDCAP_VERSION}
+            mkdir redcap_source
+            cd redcap_source
+            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_042ee976ef53cbd6ec78fbf9742292ca" git clone --depth=1 git@github.com:vanderbilt-redcap/REDCap.git redcap_v${REDCAP_VERSION}
+            cp -a redcap_v${REDCAP_VERSION}/Resources/install_files/redcap/* .
+            cp -a redcap_v${REDCAP_VERSION}/Resources/nonversioned_files/* .
+            cp ../.circleci/redcap_install_files/* .
 
 jobs:
   run-tests:
@@ -145,8 +149,10 @@ jobs:
       - run:
           name: Push to Repository
           command: |
-            sudo zip -r "/home/circleci/project/redcap_source/html-report-${REDCAP_VERSION}.zip" /home/circleci/project/coverage-report/html-report/*
-            cd /home/circleci/project/redcap_source
+            cd /home/circleci/project
+            GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa" git clone --branch redcap-cypress --depth=1 https://github.com/aldefouw/redcap_source redcap_cypress_build_reports
+            cd redcap_cypress_build_reports
+            sudo zip -r "html-report-${REDCAP_VERSION}.zip" ../coverage-report/html-report/*
             git add "html-report-${REDCAP_VERSION}.zip"
             git commit -m "Add latest HTML Report for version ${REDCAP_VERSION}"
             GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa" git push origin redcap-cypress

--- a/.circleci/redcap_install_files/database.php
+++ b/.circleci/redcap_install_files/database.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Set this variable to TRUE if you are having problems and need to see as much error logging information as
+ * possible. This will cause all errors/warnings/notices to be logged to your web server's error log. Once
+ * the issue has been resolved, we recommend setting this back to FALSE to avoid unnecessary logging of warnings.
+ */
+global $log_all_errors;
+$log_all_errors = FALSE;
+
+//********************************************************************************************************************
+// MYSQL DATABASE CONNECTION:
+// Replace the values inside the single quotes below with the values for your MySQL configuration. 
+// If not using the default port 3306, then append a colon and port number to the hostname (e.g. $hostname = 'example.com:3307';).
+
+$hostname   = 'db';         //your_mysql_host_name
+$db         = 'redcap';     //your_mysql_db_name
+$username   = 'root';       //your_mysql_db_username
+$password   = 'root';       //your_mysql_db_password
+
+// You may optionally utilize a database connection over SSL/TLS for improved security. To do so, at minimum
+// you must provide the path of the key file, the certificate file, and certificate authority file.
+$db_ssl_key  	= '';		// e.g., '/etc/mysql/ssl/client-key.pem'
+$db_ssl_cert 	= '';		// e.g., '/etc/mysql/ssl/client-cert.pem'
+$db_ssl_ca   	= '';		// e.g., '/etc/mysql/ssl/ca-cert.pem'
+$db_ssl_capath 	= NULL;
+$db_ssl_cipher 	= NULL;
+$db_ssl_verify_server_cert = false; // Set to TRUE to force the database connection to verify the SSL certificate
+
+// For greater security, you may instead want to place the database connection values in a separate file that is not 
+// accessible via the web. To do this, uncomment the line below and set it as the path to your database connection file
+// located elsewhere on your web server. The file included should contain all the variables from above.
+
+// include 'path_to_db_conn_file.php';
+
+
+//********************************************************************************************************************
+// SALT VARIABLE:
+// Add a random value for the $salt variable below, preferably alpha-numeric with 8 characters or more. This value wll be 
+// used for data de-identification hashing for data exports. Do NOT change this value once it has been initially set.
+
+$salt = '1669ed600d';
+
+
+//********************************************************************************************************************
+// DATA TRANSFER SERVICES (DTS):
+// If using REDCap DTS, uncomment the lines below and provide the database connection values for connecting to
+// the MySQL database containing the DTS tables (even if the same as the values above).
+
+// $dtsHostname 	= 'your_dts_host_name';
+// $dtsDb 			= 'your_dts_db_name';
+// $dtsUsername 	= 'your_dts_db_username';
+// $dtsPassword 	= 'your_dts_db_password';

--- a/.circleci/redcap_install_files/phpinfo.php
+++ b/.circleci/redcap_install_files/phpinfo.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>

--- a/.circleci/redcap_install_files/save-code-coverage.php
+++ b/.circleci/redcap_install_files/save-code-coverage.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+//Only run this if we're being run through apache interface
+$sapi_name = php_sapi_name();
+if (strpos($sapi_name, 'apache') !== 0) {
+    return;
+}
+
+// Get the filename being executed
+$filename = $_SERVER['SCRIPT_FILENAME'];
+
+// Get the current REDCap version
+$redcap_version = getenv('REDCAP_VERSION');
+require 'redcap_v'.$redcap_version.'/vendor/autoload.php';
+
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\Driver\Selector;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\PHP as PhpReport;
+
+$filter = new Filter;
+$filter->includeFile($filename);
+$coverage = new CodeCoverage(
+    (new Selector)->forLineCoverage($filter),
+    $filter
+);
+
+$coverage->start($_SERVER['REQUEST_URI']);
+
+
+function save_coverage()
+{
+    global $coverage;
+    $coverage->stop();
+    (new PhpReport)->process($coverage, '/tmp/path/coverage/' . bin2hex(random_bytes(16)) . '.cov');
+}
+
+register_shutdown_function('save_coverage');
+?>


### PR DESCRIPTION
@aldefouw, this removes the dependence on the `redcap_source` repo for cypress to run.  The commits might be easiest to review individually.  We are still pushing reports up to the `redcap_source` repo, but I have an item on my TODO list to change that to the `redcap_cypress_build_reports` after we transfer the `redcap_cypress` repo.  These changes are working as demonstrated by the following two screenshots:

![image](https://github.com/user-attachments/assets/206b17ab-d8af-4ec2-ba02-e9420ee5dce0)
![image](https://github.com/user-attachments/assets/2c3e6149-0c40-4d8f-a298-2229898d1581)
