### PR TITLE
Remove extraneous build steps to speed up the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,6 @@ jobs:
     environment:
     steps:
       - checkout
-      - run:
-          name: Install MySQL Client
-          command: |
-            sudo apt-get update
-            sudo apt-get install mysql-client-core-8.0
       - setup-redcap
       - run:
           name: Start Docker REDCap Container
@@ -74,11 +69,6 @@ jobs:
           name: Install composer dependencies
           command: |
             docker exec -it redcap_docker-app-1 sh -c "cd /var/www/html/redcap_v${REDCAP_VERSION} && COMPOSER_DISABLE_XDEBUG_WARN=1 composer require --dev phpunit/php-code-coverage:^11"
-      - run:
-          name: Reload REDCap
-          command: |
-            cd /home/circleci/project/redcap_docker
-            docker-compose down && REDCAP_VERSION=${REDCAP_VERSION} docker-compose up -d
       - run:
           name: Permissions on coverage files
           command: |


### PR DESCRIPTION
@kcmcg, this speeds up the cloud build even more by removing a couple of extraneous steps:

https://app.circleci.com/pipelines/circleci/BLgRjd7Ux8A2nSqbTvRf4a/Tmnaphc1X8jXxa2wyDQpqm/134/workflows/c433a58a-6727-4fda-ade3-c0941ac44e71/jobs/253